### PR TITLE
Layman Printing of Statements

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,0 +1,21 @@
+export const ADD_STATEMENT = 'ADD_STATEMENT';
+export const CLEAR_STATEMENT = 'CLEAR_STATEMENT';
+export const LANGUAGE_SELECTED = 'LANGUAGE_SELECTED';
+
+export function addStatement(statement) {
+    return {
+        type: ADD_STATEMENT,
+        statement
+    };
+}
+
+export function clearStatements() {
+    return { type: CLEAR_STATEMENT };
+}
+
+export function languageSelected(language) {
+    return {
+        type: LANGUAGE_SELECTED,
+        language
+    };
+}

--- a/app/components/Menu.js
+++ b/app/components/Menu.js
@@ -1,0 +1,48 @@
+import React, { Component, PropTypes } from 'react';
+import ClipboardButton from 'react-clipboard.js';
+import theme from '../themes/nicinabox';
+
+export default class Menu extends Component {
+    constructor(props) {
+        super(props);
+        this.clear = this.clear.bind(this);
+        this.createLanguage = this.createLanguage.bind(this);
+        this.changeLanguage = this.changeLanguage.bind(this)
+    }
+
+    clear() {
+        const { clearStatements } = this.props;
+        clearStatements();
+    }
+
+    createLanguage(l) {
+        const { language } = this.props;
+
+        return (
+            <option key={ l.id } value={ l.id }> { l.name }</option>
+        )
+    }
+
+    changeLanguage(event) {
+        const { languageSelected } = this.props
+        languageSelected(event.target.value);
+    }
+
+    render() {
+        const { language } = this.props;
+        const { statements } = this.props;
+        const { languages } = this.props;
+        const languageOptions = _.map(languages, this.createLanguage);
+
+        return (
+            <header>
+                <div className="button-panel">
+                    <button onClick={this.clear.bind(this)}>Clear</button>
+                    <ClipboardButton data-clipboard-text={JSON.stringify(statements, null, 4)}>Copy Statements</ClipboardButton>
+                    <select value = { language } onChange= { this.changeLanguage }>{ languageOptions }</select>
+                </div>
+                <div className="button-panel-helper"></div>
+            </header>
+        );
+    }
+}

--- a/app/components/Statements.js
+++ b/app/components/Statements.js
@@ -1,0 +1,67 @@
+import React, { Component, PropTypes } from 'react';
+import JSONTree from 'react-json-tree';
+import moment from 'moment';
+import 'moment-duration-format';
+import theme from '../themes/nicinabox';
+
+export default class Statements extends Component {
+    constructor(props) {
+        super(props);
+        this.foundStatement = this.foundStatement.bind(this);
+        this.state = { lastUpdated: undefined };
+    }
+
+    componentDidMount() {
+        chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+            this.foundStatement(message);
+        });
+
+        this.updateTimer = setInterval(() => {
+            // Force an update
+            this.setState({
+                lastUpdated: moment()
+            });
+        }, 1000);
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.updateTimer);
+    }
+
+    foundStatement(message) {
+        const { addStatement } = this.props;
+        addStatement(message);
+    }
+
+    render() {
+        const { statements } = this.props;
+        const { language } = this.props;
+        return (
+            <article>
+                {statements.map((s, index) => {
+                    const name = s && s.actor && s.actor.name || 'Unknown name';
+                    const verb = s && s.verb && s.verb.display && s.verb.display[language] || 'Unknown verb';
+                    // Look for an object's name. If there is no name, look for description.
+                    const object = s && s.object && s.object.definition && s.object.definition && s.object.definition.name &&  s.object.definition.name[language] || s && s.object && s.object.definition && s.object.definition && s.object.definition.description &&  s.object.definition.description[language] || 'Unknown object';
+                    const timestamp = moment(s.timestamp);
+                    const timeAgo = moment.duration(moment().diff(timestamp)).format('h[h]m[m]s[s] ago');
+                    return (
+
+                        <div key={index} className="statement-block">
+                            <div className="statement-heading">
+                                <h3>{name + ' ' + verb + ' ' + object}</h3>
+                                <span>{timeAgo}</span>
+                            </div>
+                            <JSONTree
+                                theme={theme}
+                                data={s}
+                                invertTheme={false}
+                                hideRoot={true}
+                            />
+                        </div>
+                    );
+                })}
+            </article>
+        );
+    }
+}

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -1,71 +1,36 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import JSONTree from 'react-json-tree';
-import ClipboardButton from 'react-clipboard.js';
-import moment from 'moment';
-import 'moment-duration-format';
-import theme from '../themes/nicinabox';
+import { languages } from '../data/languages';
+import * as actions from '../actions';
 
-export default class App extends Component {
+import Menu from '../components/Menu.js';
+import Statements from '../components/Statements.js'
+
+class App extends Component {
     constructor(props) {
         super(props);
-        this.state = {
-            statements: [],
-            lastUpdated: undefined
-        };
-    }
-
-    componentDidMount() {
-        chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-            this.setState({
-                statements: this.state.statements.concat(JSON.parse(message))
-            });
-        });
-
-        this.updateTimer = setInterval(() => {
-            // Force an update
-            this.setState({
-                lastUpdated: moment()
-            });
-        }, 1000);
-    }
-
-    componentWillUnmount() {
-        clearInterval(this.updateTimer);
-    }
-
-    clear() {
-        this.setState({
-            statements: []
-        });
     }
 
     render() {
         return (
-            <div>
-                <div className="button-panel">
-                    <button onClick={this.clear.bind(this)}>Clear</button>
-                    <ClipboardButton data-clipboard-text={JSON.stringify(this.state.statements, null, 4)}>Copy Statements</ClipboardButton>
-                </div>
-                {this.state.statements.map((s, index) => {
-                    const verbId = s && s.verb && s.verb.id || 'Unknown verb';
-                    const timestamp = moment(s.timestamp);
-                    const timeAgo = moment.duration(moment().diff(timestamp)).format('h[h]m[m]s[s] ago');
-                    return (
-                        <div key={index} className="statement-block">
-                            <div className="statement-heading">
-                                <h3>{verbId}</h3>
-                                <span>{timeAgo}</span>
-                            </div>
-                            <JSONTree
-                                theme={theme}
-                                data={s}
-                                invertTheme={false}
-                                hideRoot={true}
-                            />
-                        </div>
-                    );
-                })}
-            </div>
+            <main>
+                <Menu languages={languages} {...this.props} />
+                <Statements {...this.props} />
+            </main>
         );
     }
 }
+
+function mapStateToProps(state) {
+    return {
+        statements: state.statements,
+        language: state.language
+    };
+}
+
+export default connect(mapStateToProps, {
+    addStatement: actions.addStatement,
+    clearStatements: actions.clearStatements,
+    languageSelected: actions.languageSelected
+})(App);

--- a/app/data/languages.js
+++ b/app/data/languages.js
@@ -1,0 +1,50 @@
+export const languages = [
+    {
+        name: 'English',
+        id: 'en-us'
+    },
+    {
+        name: 'Germain',
+        id: 'de'
+    },
+    {
+        name: 'Español',
+        id: 'es'
+    },
+    {
+        name: 'Français',
+        id: 'fr'
+    },
+    {
+        name: 'हिंदी',
+        id: 'hi'
+    },
+    {
+        name: 'Italiano',
+        id: 'it'
+    },
+    {
+        name: 'Khmer',
+        id: 'km'
+    },
+    {
+        name: 'Melayu',
+        id: 'ms'
+    },
+    {
+        name: 'Nederlands',
+        id: 'nl'
+    },
+    {
+        name: 'Português',
+        id: 'pt-br'
+    },
+    {
+        name: 'Русский',
+        id: 'ru'
+    },
+    {
+        name: 'ภาษาไทย',
+        id: 'th'
+    }
+];

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -10,6 +10,7 @@
         "scripts": ["background.js"]
     },
     "permissions": [
+        "storage",
         "webRequest",
         "*://*/lrs*"
     ]

--- a/app/popup.js
+++ b/app/popup.js
@@ -3,10 +3,19 @@ require("file?name=[name].[ext]!./popup.html");
 require("file?name=[name].[ext]!./manifest.json");
 import React from 'react';
 import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+import configureStore from './store/configureStore';
 
 import App from './containers/App';
 import './styles.less';
 
+const store = configureStore();
+
 document.addEventListener("DOMContentLoaded", function(event) { 
-    render(<App />, document.getElementById('react-root'));
+    render(
+        <Provider store={store}>
+            <App />
+        </Provider>,
+        document.getElementById('react-root')
+    );
 });

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux';
+import * as reducers from './reducers';
+
+const rootReducer = combineReducers(reducers);
+
+export default rootReducer;

--- a/app/reducers/reducers.js
+++ b/app/reducers/reducers.js
@@ -1,0 +1,24 @@
+import * as types from '../actions';
+import {actionTypes} from 'redux-localstorage';
+
+export function statements(state = [], action) {
+    switch (action.type) {
+        case types.ADD_STATEMENT:
+            return [
+                ...state.concat(JSON.parse(action.statement))
+            ]
+        case types.CLEAR_STATEMENT:
+            return []
+        default:
+            return state;
+    }
+}
+
+export function language(state = 'en-us', action) {
+    switch (action.type) {
+        case types.LANGUAGE_SELECTED:
+            return action.language
+        default:
+            return state;
+    }
+}

--- a/app/store/chromeStorageAdapter.js
+++ b/app/store/chromeStorageAdapter.js
@@ -1,0 +1,21 @@
+// Adapter for redux-localstorage to use Chrome's chrome.storage mechanism
+export default (storage) => ({
+    0: storage,
+    put(key, value, callback) {
+        try {
+            storage.local.set({ [key]: value }, () => callback(null));
+        } catch (e) {
+            callback(e);
+        }
+    },
+
+    get(key, callback) {
+        storage.local.get(key, (value) => {
+            callback(null, value[key]);
+        });
+    },
+
+    del(key, callback) {
+        storage.local.remove(key, () => callback(null));
+    }
+});

--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -1,0 +1,37 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import { devTools } from 'redux-devtools';
+import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
+import rootReducer from '../reducers';
+import chromeStorageAdapter from './chromeStorageAdapter';
+import _ from 'lodash';
+
+import persistState, { mergePersistedState } from 'redux-localstorage';
+import filter from 'redux-localstorage-filter';
+
+// Persist our state to LocalStorage
+const reducer = compose(
+    mergePersistedState()
+)(rootReducer);
+
+// Function to create our store with middleware
+const finalCreateStore = compose(
+    persistState(chromeStorageAdapter(chrome.storage), 'elements-xapi-inspector'),
+    applyMiddleware(thunk),
+    applyMiddleware(createLogger()),
+    devTools()
+)(createStore);
+
+export default function configureStore(initialState) {
+    const store = finalCreateStore(reducer, initialState);
+
+    if (module.hot) {
+        // Enable Webpack hot module replacement for reducers
+        module.hot.accept('../reducers', () => {
+            const nextRootReducer = require('../reducers');
+            store.replaceReducer(nextRootReducer);
+        });
+    }
+
+    return store;
+}

--- a/app/styles.less
+++ b/app/styles.less
@@ -12,9 +12,13 @@ body {
 }
 
 .button-panel {
+    z-index: 999;
+    background-color: #2A2F3A;
+    position: fixed;
     display: flex;
     flex-direction: row;
     padding: 5px;
+    width: 100%;
 
     button {
         cursor: pointer;
@@ -25,8 +29,23 @@ body {
         display: block;
         margin: 5px;
     }
+    select {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        text-align-last: center;
+        margin: 5px;
+        flex-grow: 1;
+        border: 0;
+        border-radius: 0;
+        background-color: #4f5a65;
+        color: white;
+    }
 };
 
+/* Adds padding to offset the fixed nav */
+.button-panel-helper {
+    padding: 19px;
+};
 
 .statement-block {
     margin-bottom: 25px;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
     "react-clipboard.js": "^1.0.1",
     "react-dom": "^15.4.2",
     "react-json-tree": "0.10.0",
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.3",
+    "redux-devtools": "^2.1.5",
+    "redux-localstorage": "^1.0.0-rc4",
+    "redux-localstorage-filter": "^0.1.1",
+    "redux-logger": "^2.0.4",
+    "redux-thunk": "^1.0.0",
     "style-loader": "^0.12.3",
     "webpack": "^1.13.3"
   }


### PR DESCRIPTION

![menu](https://cloud.githubusercontent.com/assets/9554269/23263685/f6ce4200-f9ac-11e6-82cc-602986068cd2.gif)

This PR focuses on printing an easily readable sentence constructed from xAPI statements gathered by the extension. In addition, it features some back end updates.

# Changes
* Layman printing of statements
  * An added button controls what language is used when printed out. If that language is not found in the statement, the statement's `verb` and `object` will print out as `Unknown`.
  * If an object has no name assigned to it, it will look for its description before printing it as `Unknown Object`
* The `App` container was split into components
  * `Statements` component hold the list of statements
  * `Menu` component holds the buttons for interacting with the statements - is now fixed to the top of the window
* Redux was implemented to provide persistence between sessions and components